### PR TITLE
Remove Heroku email, as API key is enough to trigger Docker builds and pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ env:
   EMAIL_ADDRESS: ${{ secrets.EMAIL_ADDRESS }}
   EPIC_GAMES_PASSWORD: ${{ secrets.EPIC_GAMES_PASSWORD }}
   GIT_HASH: master
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   TEMPORARY_EMAIL_COOKIE: ${{ secrets.TEMPORARY_EMAIL_COOKIE }}
   TOTP_MFA: ${{ secrets.TOTP_MFA }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   APP_NAME: ${{ secrets.APP_NAME }}
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,6 @@ env:
   EMAIL_ADDRESS: ${{ secrets.EMAIL_ADDRESS }}
   EPIC_GAMES_PASSWORD: ${{ secrets.EPIC_GAMES_PASSWORD }}
   GIT_HASH: master
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   TOTP_MFA: ${{ secrets.TOTP_MFA }}
 

--- a/.github/workflows/utility.yml
+++ b/.github/workflows/utility.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   APP_NAME: ${{ secrets.APP_NAME }}
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   TEMPORARY_EMAIL_COOKIE: ${{ secrets.TEMPORARY_EMAIL_COOKIE }}
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Usage is simply, fast, and user friendly! The application will run each hour aft
 
 1. Create a fork of this project
 2. Go to your forked repo Settings > Secrets and add secrets for:
-  * HEROKU_EMAIL (the email you used to sign up for Heroku)
   * HEROKU_API_KEY (yoru Heroku API key - can be found in **[Account Setings](https://dashboard.heroku.com/account)** -> APi Keys)
   * APP_NAME (the name of the Heroku application, this must be unqiue across Heroku and will fail if it is not)
   * EMAIL_ADDRESS (your Epic Games email address)

--- a/deploy_update_app.sh
+++ b/deploy_update_app.sh
@@ -31,7 +31,7 @@ function heroku_envar_bootstrap {
     heroku config:set SMTP_PORT="465" -a "${APP_NAME}" > /dev/null
     heroku config:set EMAIL_SENDER_ADDRESS="$(heroku config:get MAILGUN_SMTP_LOGIN -a "${APP_NAME}")" -a "${APP_NAME}" > /dev/null
     heroku config:set EMAIL_SENDER_NAME="[${APP_NAME}] Epic Games Free Captcha" -a "${APP_NAME}" > /dev/null
-    heroku config:set EMAIL_RECIPIENT_ADDRESS="${EMAIL_ADDRESS:-$HEROKU_EMAIL}" -a "${APP_NAME}" > /dev/null
+    heroku config:set EMAIL_RECIPIENT_ADDRESS="${EMAIL_ADDRESS}" -a "${APP_NAME}" > /dev/null
     heroku config:set SMTP_SECURE="true" -a "${APP_NAME}" > /dev/null
     heroku config:set SMTP_USERNAME="$(heroku config:get MAILGUN_SMTP_LOGIN -a "${APP_NAME}")" -a "${APP_NAME}" > /dev/null
     heroku config:set SMTP_PASSWORD="$(heroku config:get MAILGUN_SMTP_PASSWORD -a "${APP_NAME}")" -a "${APP_NAME}" > /dev/null
@@ -113,19 +113,6 @@ do
     esac
 done
 
-function login_heroku {
-printf "Modify netrc file to include Heroku details.\n"
-cat >~/.netrc <<EOF
-machine api.heroku.com
-    login ${HEROKU_EMAIL}
-    password ${HEROKU_API_KEY}
-machine git.heroku.com
-    login ${HEROKU_EMAIL}
-    password ${HEROKU_API_KEY}
-EOF
-}
-
-login_heroku
 printf "App_Name: %s\n" "$APP_NAME";
 printf "Git Hash: %s\n" "$GIT_HASH";
 
@@ -137,13 +124,11 @@ then
     printf "Congrats! Your new EpicGames FreeGames instance is ready to use! Since we are using Github actions, we can make sure we restart this process daily!\n"
 elif [[ ${STRATEGY_TYPE} = "run" ]]
 then
-    login_heroku
     heroku restart -a "${APP_NAME}"
     printf "Check the logs in Heroku, as they may contain sensitive details we don't want to print here!\n"
     exit 0
 elif [[ ${STRATEGY_TYPE} = "cookie" ]]
 then
-    login_heroku
     redis-cli -u "$(heroku config:get REDISTOGO_URL -a "${APP_NAME}")" set EMAIL_COOKIE "${TEMPORARY_EMAIL_COOKIE}" > /dev/null
     exit 0
 else


### PR DESCRIPTION
Per a helpful PR from my Bitwarden repo, we can remove the need for the login rc hack and use just the Heroku API.