### PR TITLE
Change `apt` to `apt-get`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,5 +25,5 @@ jobs:
       with:
         fetch-depth: 1
     - run: curl https://cli-assets.heroku.com/install.sh | sh
-    - run: sudo apt update && sudo apt install jq openssl redis -y
+    - run: sudo apt-get update && sudo apt-get install jq openssl redis -y
     - run: bash deploy_update_app.sh -a $APP_NAME -g $GIT_HASH -t deploy -o TOTP_MFA

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,5 +24,5 @@ jobs:
       with:
         fetch-depth: 1
     - run: curl https://cli-assets.heroku.com/install.sh | sh
-    - run: sudo apt update && sudo apt install jq openssl redis -y
+    - run: sudo apt-get update && sudo apt-get install jq openssl redis -y
     - run: bash deploy_update_app.sh -a $APP_NAME -t run

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         fetch-depth: 1
     - run: curl https://cli-assets.heroku.com/install.sh | sh
-    - run: sudo apt update && sudo apt install jq openssl redis -y
+    - run: sudo apt-get update && sudo apt-get install jq openssl redis -y
     - run: bash deploy_update_app.sh -a $APP_NAME -g $GIT_HASH -t update

--- a/.github/workflows/utility.yml
+++ b/.github/workflows/utility.yml
@@ -17,5 +17,5 @@ jobs:
       with:
         fetch-depth: 1
     - run: curl https://cli-assets.heroku.com/install.sh | sh
-    - run: sudo apt update && sudo apt install jq openssl redis -y
+    - run: sudo apt-get update && sudo apt-get install jq openssl redis -y
     - run: bash deploy_update_app.sh -a $APP_NAME -t cookie


### PR DESCRIPTION
`apt` is not designed to be used in scripts, whereas `apt-get` is.
Gets rid of this warning: `WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`